### PR TITLE
Completely untested post.lisp change: use <main>

### DIFF
--- a/src/data-viewers/post.lisp
+++ b/src/data-viewers/post.lisp
@@ -66,7 +66,7 @@
 
 (defun post-body-to-html (post)
   (schema-bind (:post post (post-id url question title html-body) :qualifier :body)
-    <div class=("post~{ ~A~}" (list-cond
+    <main class=("post~{ ~A~}" (list-cond
 			       (url "link-post")
 			       (question "question-post")))>
       <h1 class="post-title">
@@ -80,4 +80,4 @@
 	    (write-sequence (clean-html* (or html-body "") :with-toc t :post-id post-id) *html-output*))
       </div>
       (with-html-stream-output #|(post-meta-to-html post :body nil) TODO: don't use js to insert bottom-post-meta|#)
-    </div>))
+    </main>))


### PR DESCRIPTION
This should help not-particularly-intelligent read-it-later parsers figure out what the important part of a post page is.

As a disclaimer, I'd like to publicly note that this change is completely untested and was written by someone whose last Lisp exposure was maybe two weeks of basic Clojure five years ago. If any CSS depends on this element being a div, then this change will break things. That said, I didn't see "div.post" anywhere in the dark-mode CSS.