### PR TITLE
Cookieless dark-theme preferrers get dark mode

### DIFF
--- a/www/script.js
+++ b/www/script.js
@@ -861,7 +861,13 @@ function setWidthAdjustButtonsAccesskey() {
 
 function injectThemeSelector() {
 	GWLog("injectThemeSelector");
-	let currentTheme = readCookie("theme") || "default";
+	let currentTheme = readCookie("theme");
+	if (!currentTheme) {
+		currentTheme = "default";
+		if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+			currentTheme = "dark";
+		}
+	}
 	let themeSelector = addUIElement(
 		"<div id='theme-selector' class='theme-selector'>" +
 		String.prototype.concat.apply("", GW.themeOptions.map(themeOption => {


### PR DESCRIPTION
As much as I would like to believe this change (1) works (2) breaks nothing, I haven't stood up a test server and actually made sure of either.