### PR TITLE
Remove the question post checkbox from post creation/editing

### DIFF
--- a/lw2.lisp
+++ b/lw2.lisp
@@ -1377,7 +1377,6 @@
                                     :csrf-token csrf-token
                                     :title (cdr (assoc :title post-body))
                                     :url (cdr (assoc :url post-body))
-				    :question (cdr (assoc :question post-body))
 				    :tags-supported (typep *current-backend* 'backend-accordius)
 				    :tags (when (and post-id (typep *current-backend* 'backend-accordius)) (do-wl-rest-query (format nil "posts/~a/update_tagset/" post-id) '()))
                                     :post-id post-id
@@ -1388,7 +1387,7 @@
 				    :submit-to-frontpage (if post-id (cdr (assoc :submit-to-frontpage post-body)) t)
                                     :markdown-source (or (and post-id (markdown-source :post post-id html-body))
 							 "")))))
-    (:post (text question submit-to-frontpage)
+    (:post (text submit-to-frontpage)
      (let ((lw2-auth-token *current-auth-token*)
            (url (if (string= url "") nil url)))
        (assert lw2-auth-token)
@@ -1400,8 +1399,7 @@
 		(t :meta (or (string= section "meta") :false))
 		((not post-id) :is-event nil)
 		(t :draft (or (string= section "drafts") :false))
-		((typep *current-backend* 'backend-lw2-misc-features) :submit-to-frontpage (and submit-to-frontpage t))
-		((not post-id) :question (if question t :false))))
+		((typep *current-backend* 'backend-lw2-misc-features) :submit-to-frontpage (and submit-to-frontpage t))))
 	      (post-unset
 	       (list-cond
 		((not link-post) :url t)))

--- a/templates/edit-post.html
+++ b/templates/edit-post.html
@@ -11,9 +11,6 @@
 		<label for="tags">Tags:</label>
 		<input type="text" name="tags" id="tags-input" value="{{ tags }}">
 		{% endif %}
-		<input type="checkbox" class="question-checkbox" name="question" id="question"{% if question %} checked{% endif %}>
-		<label for="question" class="iconify">Question post</label>
-		
 		{% if lesswrong-misc %}
 		<input type="checkbox" name="submit-to-frontpage" id="submit-to-frontpage"{% if submit-to-frontpage %} checked{% endif %}>
 		<label for="submit-to-frontpage">Moderators may promote to frontpage</label>

--- a/www/script.js
+++ b/www/script.js
@@ -3118,7 +3118,7 @@ function setEditPostPageSubmitButtonText() {
 	GWLog("setEditPostPageSubmitButtonText");
 	if (!query("#content").hasClass("edit-post-page")) return;
 
-	queryAll("input[type='radio'][name='section'], .question-checkbox").forEach(radio => {
+	queryAll("input[type='radio'][name='section']").forEach(radio => {
 		radio.addEventListener("change", GW.postSectionSelectorValueChanged = (event) => {
 			GWLog("GW.postSectionSelectorValueChanged");
 			updateEditPostPageSubmitButtonText();
@@ -3133,9 +3133,9 @@ function updateEditPostPageSubmitButtonText() {
 	if (query("input#drafts").checked == true) 
 		submitButton.value = "Save Draft";
 	else if (query(".posting-controls").hasClass("edit-existing-post"))
-		submitButton.value = query(".question-checkbox").checked ? "Save Question" : "Save Post";
+		submitButton.value = "Save Post";
 	else
-		submitButton.value = query(".question-checkbox").checked ? "Submit Question" : "Submit Post";
+		submitButton.value = "Submit Post";
 }
 
 /*****************/
@@ -4736,7 +4736,6 @@ function mainInitializer() {
 	// with icons, to save space.
 	if (GW.isMobile && query(".edit-post-page")) {
 		query("label[for='link-post']").innerHTML = "&#xf0c1";
-		query("label[for='question']").innerHTML = "&#xf128";
 	}
 
 	// Add error message (as placeholder) if user tries to click Search with


### PR DESCRIPTION
## Summary

LessWrong is removing the ability to create new question posts (or convert existing posts into questions); existing question posts will keep displaying as questions. This PR removes the corresponding UI from GreaterWrong's post creation/edit form:

- Remove the "Question post" checkbox from `templates/edit-post.html`
- Stop passing `:question` to the template and stop sending `question` in the post-creation mutation in `lw2.lisp` (the corresponding ForumMagnum change restricts who can set the `question` field on `createPost`, so continuing to send it - even as `false` - would start failing validation once that lands)
- Remove the checkbox references in `www/script.js` (submit-button text and the mobile icon-label replacement, which would otherwise throw on a null `query()` result)

Not included: the now-unused `.question-checkbox` rules in `www/style.css.php` / `www/style_mobile_additions.css.php`, since I can't run the php pre-commit hook to regenerate the compiled CSS here. Happy to add that if you'd prefer.

Corresponding ForumMagnum PR: https://github.com/ForumMagnum/ForumMagnum/pull/12587